### PR TITLE
Fixed a bug when saving the best model

### DIFF
--- a/ptsr/utils/trainer.py
+++ b/ptsr/utils/trainer.py
@@ -191,7 +191,7 @@ class Trainer():
 
                 if not self.cfg.SOLVER.TEST_ONLY:
                     is_best = False
-                    if best[0][idx_data, idx_scale] >= self.best_val_score:
+                    if best[0][idx_data, idx_scale] > self.best_val_score:
                         self.best_val_score = best[0][idx_data, idx_scale]
                         is_best = True
                     self.ckp.save(self, iteration, is_best, self.iter_start,


### PR DESCRIPTION
The bug saves the latest model as the best model during training.

For example, when the code runs to line 194,

iteration 1000:
PSNR: 30
best[0][idx_data, idx_scale]: 30
self.best_val_score: 0
is_best = True (30 >=0)

iteration 2000:
PSNR: 29 (**poor**)
best[0][idx_data, idx_scale]: 30
self.best_val_score: 30
is_best = True (30 >= 30. **BUG appears**, the code will save the model with PSNR=29 as the best model.)